### PR TITLE
Testability refactor

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -35,4 +35,10 @@ config :snowplow_tracker,
     recv_timeout: 2000,
     hackney: [pool: :snowplow_hackney_pool]
   ],
-  table: :snowplow_events
+  table: :snowplow_events,
+  emitters: [
+    server: [
+      initial_delay: 5_000,
+      next_delay: 120_000
+    ]
+  ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,4 +5,10 @@ config :snowplow_tracker,
     timeout: 5000,
     recv_timeout: 2000
   ],
-  table: :snowplow_events_test
+  table: :snowplow_events_test,
+  emitters: [
+    server: [
+      initial_delay: 100,
+      next_delay: 500
+    ]
+  ]

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -2,14 +2,9 @@ defmodule SnowplowTracker.Application do
   use Application
 
   def start(_type, _args) do
-    children =
-      if Mix.env() != :test do
-        [
-          {SnowplowTracker.Emitters.Server, []}
-        ]
-      else
-        []
-      end
+    children = [
+      {SnowplowTracker.Emitters.Server, []}
+    ]
 
     Supervisor.start_link(children, strategy: :one_for_all)
   end

--- a/lib/snowplow_tracker/emitters/helper.ex
+++ b/lib/snowplow_tracker/emitters/helper.ex
@@ -49,6 +49,6 @@ defmodule SnowplowTracker.Emitters.Helper do
   end
 
   defp do_generate_endpoint(protocol, uri, port, _payload, @post_method) do
-    "#{protocol}://#{uri}#{port}/#{@post_vendor}?#{@post_version}"
+    "#{protocol}://#{uri}#{port}/#{@post_vendor}/#{@post_version}"
   end
 end

--- a/lib/snowplow_tracker/emitters/processor.ex
+++ b/lib/snowplow_tracker/emitters/processor.ex
@@ -8,7 +8,7 @@ defmodule SnowplowTracker.Emitters.Processor do
   alias SnowplowTracker.Emitters.Cache
 
   @chunk_size 100
-  @headers [Accept: Constants.post_content_type()]
+  @headers ["Content-Type": Constants.post_content_type()]
   @options Application.get_env(:snowplow_tracker, :default_options) || []
   @table Application.get_env(:snowplow_tracker, :table)
 

--- a/lib/snowplow_tracker/emitters/server.ex
+++ b/lib/snowplow_tracker/emitters/server.ex
@@ -49,12 +49,16 @@ defmodule SnowplowTracker.Emitters.Server do
   end
 
   defp schedule_initial_job() do
-    # In 5 seconds
-    Process.send_after(self(), :perform, 1_000)
+    Process.send_after(self(), :perform, initial_delay())
   end
 
   defp schedule_next_job() do
-    # In 120 seconds
-    Process.send_after(self(), :perform, 5_000)
+    Process.send_after(self(), :perform, next_delay())
   end
+
+  defp server_config, do: Application.get_env(:snowplow_tracker, :emitters)[:server]
+
+  defp initial_delay, do: server_config()[:initial_delay]
+
+  defp next_delay, do: server_config()[:next_delay]
 end

--- a/lib/snowplow_tracker/emitters/server.ex
+++ b/lib/snowplow_tracker/emitters/server.ex
@@ -1,6 +1,6 @@
 defmodule SnowplowTracker.Emitters.Server do
   @moduledoc """
-  This module defines the genserver that will be responsible for scheduling the jobs to 
+  This module defines the genserver that will be responsible for scheduling the jobs to
   fetch events from ETS
   """
 
@@ -50,11 +50,11 @@ defmodule SnowplowTracker.Emitters.Server do
 
   defp schedule_initial_job() do
     # In 5 seconds
-    Process.send_after(self(), :perform, 5_000)
+    Process.send_after(self(), :perform, 1_000)
   end
 
   defp schedule_next_job() do
     # In 120 seconds
-    Process.send_after(self(), :perform, 120_000)
+    Process.send_after(self(), :perform, 5_000)
   end
 end

--- a/lib/snowplow_tracker/helper.ex
+++ b/lib/snowplow_tracker/helper.ex
@@ -26,16 +26,14 @@ defmodule SnowplowTracker.Helper do
   end
 
   defp add_contexts(payload, contexts, encode) do
-    json_contexts = for context <- contexts, do: SelfDescribingJson.get(context)
-
     sdj = %SelfDescribingJson{
       schema: Constants.schema_contexts(),
-      data: json_contexts
+      data: contexts
     }
 
     Payload.add_json(
       payload,
-      SelfDescribingJson.get(sdj),
+      sdj,
       Constants.context_encoded(),
       Constants.context(),
       encode

--- a/test/snowplow_tracker/emitters/helper_test.exs
+++ b/test/snowplow_tracker/emitters/helper_test.exs
@@ -40,7 +40,7 @@ defmodule SnowplowTracker.Emitters.HelperTest do
           "POST"
         )
 
-      assert String.contains?(url, "http://localhost:8000/com.snowplowanalytics.snowplow?tp2")
+      assert String.contains?(url, "http://localhost:8000/com.snowplowanalytics.snowplow/tp2")
     end
   end
 end

--- a/test/snowplow_tracker/helper_test.exs
+++ b/test/snowplow_tracker/helper_test.exs
@@ -63,7 +63,7 @@ defmodule SnowplowTracker.HelperTest do
         "tv" => "elixir-0.1.0",
         "uid" => "UCANTSEEME",
         "cx" =>
-          "IntcImRhdGFcIjpbXCJ7XFxcImRhdGFcXFwiOlxcXCJkYXRhXFxcIixcXFwic2NoZW1hXFxcIjpcXFwidGVzdF9zY2hlbWFcXFwifVwiXSxcInNjaGVtYVwiOlwiaWdsdTpjb20uc25vd3Bsb3dhbmFseXRpY3Muc25vd3Bsb3cvY29udGV4dHMvanNvbnNjaGVtYS8xLTAtMVwifSI="
+          "eyJkYXRhIjpbeyJkYXRhIjoiZGF0YSIsInNjaGVtYSI6InRlc3Rfc2NoZW1hIn1dLCJzY2hlbWEiOiJpZ2x1OmNvbS5zbm93cGxvd2FuYWx5dGljcy5zbm93cGxvdy9jb250ZXh0cy9qc29uc2NoZW1hLzEtMC0xIn0="
       }
 
       response =
@@ -89,7 +89,7 @@ defmodule SnowplowTracker.HelperTest do
         "tv" => "elixir-0.1.0",
         "uid" => "UCANTSEEME",
         "co" =>
-          "\"{\\\"data\\\":[\\\"{\\\\\\\"data\\\\\\\":\\\\\\\"data\\\\\\\",\\\\\\\"schema\\\\\\\":\\\\\\\"test_schema\\\\\\\"}\\\"],\\\"schema\\\":\\\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1\\\"}\""
+          ~s({"data":[{"data":"data","schema":"test_schema"}],"schema":"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1"})
       }
 
       response =


### PR DESCRIPTION
This PR introduces a couple of changes to allow end-to-end testing involving `SnowplowTracker.Emitters.Server` by making the delays configurable.